### PR TITLE
Bugfix/issue 5 build with muiltiple dependencies

### DIFF
--- a/Dewey.Build.Test/BuildCommandHandlerTest.cs
+++ b/Dewey.Build.Test/BuildCommandHandlerTest.cs
@@ -1,4 +1,5 @@
 ﻿using Dewey.Build.Events;
+using Dewey.Manifest.Dependency;
 using Dewey.Messaging;
 using Dewey.State.Messages;
 using Dewey.Test;
@@ -18,7 +19,8 @@ namespace Dewey.Build.Test
         Mock<ICommandProcessor> commandProcessorMock;
         Mock<IEventAggregator> eventAggregatorMock;
         Mock<IBuildActionFactory> buildActionFactoryMock;
-        Mock<IBuildElementLoader> buildElementLoader;
+        Mock<IBuildElementLoader> buildElementLoaderMock;
+        Mock<IDependencyElementLoader> dependencyElementLoaderMock;
 
         Fixture fixture;
         BuildCommandHandler target;
@@ -28,11 +30,12 @@ namespace Dewey.Build.Test
             commandProcessorMock = new Mock<ICommandProcessor>();
             eventAggregatorMock = new Mock<IEventAggregator>();
             buildActionFactoryMock = new Mock<IBuildActionFactory>();
-            buildElementLoader = new Mock<IBuildElementLoader>();
+            buildElementLoaderMock = new Mock<IBuildElementLoader>();
+            dependencyElementLoaderMock = new Mock<IDependencyElementLoader>();
 
             fixture = new Fixture();
             fixture.Register<File.IManifestFileReader>(() => { return new MockManifestFileReader() { DirectoryName = "test" }; });
-            target = new BuildCommandHandler(commandProcessorMock.Object, eventAggregatorMock.Object, buildActionFactoryMock.Object, buildElementLoader.Object);
+            target = new BuildCommandHandler(commandProcessorMock.Object, eventAggregatorMock.Object, buildActionFactoryMock.Object, buildElementLoaderMock.Object, dependencyElementLoaderMock.Object);
         }
 
         //Fixes: Issue #5
@@ -42,26 +45,38 @@ namespace Dewey.Build.Test
             //Given
             var buildCommand = new BuildCommand("testComponentName", true);
             var getComponentResult = fixture.Create<GetComponentResult>();
-            getComponentResult = getComponentResult.WithCommand(new GetComponent(buildCommand.ComponentName));
-            getComponentResult = getComponentResult.WithComponent(getComponentResult.Component.WithComponentMandifest(getComponentResult.Component.ComponentManifest.WithName(getComponentResult.Command.ComponentName)));
-            var buildElementResult = fixture.Create<BuildElementResult>();
-            buildElementResult = buildElementResult.WithCommand(buildCommand);
-
+            getComponentResult = getComponentResult.WithCommand(new GetComponent(buildCommand.ComponentName))
+                                                   .WithComponent(getComponentResult.Component.WithComponentMandifest(getComponentResult.Component.ComponentManifest.WithName(buildCommand.ComponentName)));
             commandProcessorMock.Setup(x => x.Execute(getComponentResult.Command)).Callback<ICommand>((command) =>
             {
                 target.Handle(getComponentResult);
             });
 
-            buildElementLoader.Setup(x => x.LoadFromComponentManifest(buildCommand, getComponentResult.Component.ComponentElement)).Callback(() =>
+            var buildElementResult = fixture.Create<BuildElementResult>();
+            buildElementResult = buildElementResult.WithCommand(buildCommand);
+            buildElementLoaderMock.Setup(x => x.LoadFromComponentManifest(buildCommand, getComponentResult.Component.ComponentElement)).Callback(() =>
             {
                 target.Handle(buildElementResult);
+            });
+
+            var dependencyElementResult = fixture.Create<DependencyElementResult>().WithType(DependencyElementResult.COMPONENT_DEPENDENCY_TYPE);
+            dependencyElementLoaderMock.Setup(x => x.LoadFromComponentManifest(getComponentResult.Component.ComponentElement)).Callback(() =>
+            {
+                target.Handle(dependencyElementResult);
+            });
+
+            var dependecyBuildCommand = new BuildCommand(dependencyElementResult.Name, true);
+            commandProcessorMock.Setup(x => x.Execute(dependecyBuildCommand)).Callback(() =>
+            {
+                var childDependencyElementResult = fixture.Create<DependencyElementResult>();
+                target.Handle(childDependencyElementResult);
             });
 
             //When
             target.Execute(buildCommand);
 
             //Then
-
+            commandProcessorMock.Verify(x => x.Execute(dependecyBuildCommand), Times.Once, "A build command was not dispatched for the dependency.");
         }
     }
 }

--- a/Dewey.Build.Test/BuildCommandHandlerTest.cs
+++ b/Dewey.Build.Test/BuildCommandHandlerTest.cs
@@ -1,0 +1,67 @@
+﻿using Dewey.Build.Events;
+using Dewey.Messaging;
+using Dewey.State.Messages;
+using Dewey.Test;
+using Moq;
+using Ploeh.AutoFixture;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dewey.Build.Test
+{
+    public class BuildCommandHandlerTest
+    {
+        Mock<ICommandProcessor> commandProcessorMock;
+        Mock<IEventAggregator> eventAggregatorMock;
+        Mock<IBuildActionFactory> buildActionFactoryMock;
+        Mock<IBuildElementLoader> buildElementLoader;
+
+        Fixture fixture;
+        BuildCommandHandler target;
+
+        public BuildCommandHandlerTest()
+        {
+            commandProcessorMock = new Mock<ICommandProcessor>();
+            eventAggregatorMock = new Mock<IEventAggregator>();
+            buildActionFactoryMock = new Mock<IBuildActionFactory>();
+            buildElementLoader = new Mock<IBuildElementLoader>();
+
+            fixture = new Fixture();
+            fixture.Register<File.IManifestFileReader>(() => { return new MockManifestFileReader() { DirectoryName = "test" }; });
+            target = new BuildCommandHandler(commandProcessorMock.Object, eventAggregatorMock.Object, buildActionFactoryMock.Object, buildElementLoader.Object);
+        }
+
+        //Fixes: Issue #5
+        [Fact]
+        public void BuildCommandHandler_onlyBuildsDependciesForCommandsComponent()
+        {
+            //Given
+            var buildCommand = new BuildCommand("testComponentName", true);
+            var getComponentResult = fixture.Create<GetComponentResult>();
+            getComponentResult = getComponentResult.WithCommand(new GetComponent(buildCommand.ComponentName));
+            getComponentResult = getComponentResult.WithComponent(getComponentResult.Component.WithComponentMandifest(getComponentResult.Component.ComponentManifest.WithName(getComponentResult.Command.ComponentName)));
+            var buildElementResult = fixture.Create<BuildElementResult>();
+            buildElementResult = buildElementResult.WithCommand(buildCommand);
+
+            commandProcessorMock.Setup(x => x.Execute(getComponentResult.Command)).Callback<ICommand>((command) =>
+            {
+                target.Handle(getComponentResult);
+            });
+
+            buildElementLoader.Setup(x => x.LoadFromComponentManifest(buildCommand, getComponentResult.Component.ComponentElement)).Callback(() =>
+            {
+                target.Handle(buildElementResult);
+            });
+
+            //When
+            target.Execute(buildCommand);
+
+            //Then
+
+        }
+    }
+}

--- a/Dewey.Build.Test/BuildCommandHandlerTest.cs
+++ b/Dewey.Build.Test/BuildCommandHandlerTest.cs
@@ -59,8 +59,8 @@ namespace Dewey.Build.Test
                 target.Handle(buildElementResult);
             });
 
-            var dependencyElementResult = fixture.Create<DependencyElementResult>().WithType(DependencyElementResult.COMPONENT_DEPENDENCY_TYPE);
-            dependencyElementLoaderMock.Setup(x => x.LoadFromComponentManifest(getComponentResult.Component.ComponentElement)).Callback(() =>
+            var dependencyElementResult = fixture.Create<DependencyElementResult>().WithType(DependencyElementResult.COMPONENT_DEPENDENCY_TYPE).WithComponentManifest(getComponentResult.Component.ComponentManifest);
+            dependencyElementLoaderMock.Setup(x => x.LoadFromComponentManifest(getComponentResult.Component.ComponentManifest, getComponentResult.Component.ComponentElement)).Callback(() =>
             {
                 target.Handle(dependencyElementResult);
             });

--- a/Dewey.Build.Test/BuildElementResultTest.cs
+++ b/Dewey.Build.Test/BuildElementResultTest.cs
@@ -9,18 +9,27 @@ namespace Dewey.Build.Test
 {
     public class BuildElementResultTest
     {
+        Mock<IEventAggregator> eventAggregatorMock;
+
+        BuildElementLoader target;
+
+        public BuildElementResultTest()
+        {
+            eventAggregatorMock = new Mock<IEventAggregator>();
+            target = new BuildElementLoader(eventAggregatorMock.Object);
+        }
+
         [Fact]
         public void LoadBuildElementsFromComponentManifest_publishes_a_NoBuildElementsFoundResult_for_a_componentManifest_without_a_builds_element()
         {
             //Given
-            var eventAggregatorMock = new Mock<IEventAggregator>();
             var buildCommand = new Fixture().Create<BuildCommand>();
             XElement componentElement = XElement.Parse("<componentManifest />");
 
             var expectedResult = new NoBuildElementsFoundResult(buildCommand, componentElement);
 
             //When
-            BuildElementResult.LoadBuildElementsFromComponentManifest(buildCommand, componentElement, eventAggregatorMock.Object);
+            target.LoadFromComponentManifest(buildCommand, componentElement);
 
             //Then
             eventAggregatorMock.Verify(x => x.PublishEvent(expectedResult), Times.Once);
@@ -30,14 +39,13 @@ namespace Dewey.Build.Test
         public void LoadBuildElementsFromComponentManifest_publishes_a_NoBuildElementsFoundResult_for_a_componentManifest_without_any_build_elements()
         {
             //Given
-            var eventAggregatorMock = new Mock<IEventAggregator>();
             var buildCommand = new Fixture().Create<BuildCommand>();
             XElement componentElement = XElement.Parse("<componentManifest><builds /></componentManifest>");
 
             var expectedResult = new NoBuildElementsFoundResult(buildCommand, componentElement);
 
             //When
-            BuildElementResult.LoadBuildElementsFromComponentManifest(buildCommand, componentElement, eventAggregatorMock.Object);
+            target.LoadFromComponentManifest(buildCommand, componentElement);
 
             //Then
             eventAggregatorMock.Verify(x => x.PublishEvent(expectedResult), Times.Once);
@@ -47,7 +55,6 @@ namespace Dewey.Build.Test
         public void LoadBuildElementsFromComponentManifest_publishes_a_BuildElementMissingTypeAttributeResult_for_a_build_element_without_a_type()
         {
             //Given
-            var eventAggregatorMock = new Mock<IEventAggregator>();
             var buildCommand = new Fixture().Create<BuildCommand>();
             XElement componentElement = XElement.Parse("<componentManifest/>");
             XElement buildsElement = XElement.Parse("<builds/>");
@@ -61,7 +68,7 @@ namespace Dewey.Build.Test
             var expectedResult2 = new BuildElementMissingTypeAttributeResult(buildCommand, buildElement2);
 
             //When
-            BuildElementResult.LoadBuildElementsFromComponentManifest(buildCommand, componentElement, eventAggregatorMock.Object);
+            target.LoadFromComponentManifest(buildCommand, componentElement);
 
             //Then
             eventAggregatorMock.Verify(x => x.PublishEvent(expectedResult1), Times.Once);
@@ -72,7 +79,6 @@ namespace Dewey.Build.Test
         public void LoadBuildElementsFromComponentManifest_publishes_a_BuildElementResult_for_a_build_element_with_a_type()
         {
             //Given
-            var eventAggregatorMock = new Mock<IEventAggregator>();
             var buildCommand = new Fixture().Create<BuildCommand>();
             XElement componentElement = XElement.Parse("<componentManifest/>");
             XElement buildsElement = XElement.Parse("<builds/>");
@@ -86,7 +92,7 @@ namespace Dewey.Build.Test
             var expectedResult2 = new BuildElementResult(buildCommand, buildElement2, "b");
 
             //When
-            BuildElementResult.LoadBuildElementsFromComponentManifest(buildCommand, componentElement, eventAggregatorMock.Object);
+            target.LoadFromComponentManifest(buildCommand, componentElement);
 
             //Then
             eventAggregatorMock.Verify(x => x.PublishEvent(expectedResult1), Times.Once);

--- a/Dewey.Build.Test/Dewey.Build.Test.csproj
+++ b/Dewey.Build.Test/Dewey.Build.Test.csproj
@@ -68,6 +68,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BuildCommandHandlerTest.cs" />
     <Compile Include="BuildElementResultTest.cs" />
     <Compile Include="MSBuildTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -84,6 +85,10 @@
     <ProjectReference Include="..\Dewey.Messaging\Dewey.Messaging.csproj">
       <Project>{a3986e8a-3009-41b1-8636-0c431305255c}</Project>
       <Name>Dewey.Messaging</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Dewey.State\Dewey.State.csproj">
+      <Project>{972C3E2D-B209-4C63-97DA-FA4C16822E21}</Project>
+      <Name>Dewey.State</Name>
     </ProjectReference>
     <ProjectReference Include="..\Dewey.Test\Dewey.Test.csproj">
       <Project>{8f96ac59-2297-4885-b5a7-8d286ce8dab6}</Project>

--- a/Dewey.Build/BuildActionFactory.cs
+++ b/Dewey.Build/BuildActionFactory.cs
@@ -4,11 +4,18 @@ using System.Linq;
 
 namespace Dewey.Build
 {
-    class BuildActionFactory
+    public class BuildActionFactory : IBuildActionFactory
     {
-        public static IBuildAction CreateBuildAction(string buildType, Container container)
+        private readonly Container _container;
+
+        public BuildActionFactory(Container container)
         {
-            var buildActions = container.GetAllInstances<IBuildAction>().ToDictionary(x => x.BuildType);
+            _container = container;
+        }
+
+        public IBuildAction CreateBuildAction(string buildType)
+        {
+            var buildActions = _container.GetAllInstances<IBuildAction>().ToDictionary(x => x.BuildType);
 
             IBuildAction buildAction;
             if(!buildActions.TryGetValue(buildType, out buildAction))

--- a/Dewey.Build/BuildCommand.cs
+++ b/Dewey.Build/BuildCommand.cs
@@ -13,9 +13,10 @@ namespace Dewey.Build
 
         public bool BuildDependencies { get; private set; }
 
-        BuildCommand()
+        public BuildCommand(string componentName, bool buildDependencies)
         {
-
+            ComponentName = componentName;
+            BuildDependencies = buildDependencies;
         }
 
         public static BuildCommand Create(string[] args)
@@ -33,12 +34,7 @@ namespace Dewey.Build
             var switches = arguments.Where(arg => arg.StartsWith("-"));
             var buildDependencies = switches.Any(s => s.Contains("d"));
 
-            return Create(componentName, buildDependencies);
-        }
-
-        public static BuildCommand Create(string componentName, bool buildDependencies)
-        {
-            return new BuildCommand() { ComponentName = componentName, BuildDependencies = buildDependencies };
+            return new BuildCommand(componentName, buildDependencies);
         }
 
         public override string ToString()

--- a/Dewey.Build/BuildCommand.cs
+++ b/Dewey.Build/BuildCommand.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Dewey.Build
 {
-    public class BuildCommand : ICommand
+    public class BuildCommand : ICommand, IEquatable<BuildCommand>
     {
         public const string COMMAND_TEXT = "build";
 
@@ -43,6 +43,46 @@ namespace Dewey.Build
             if (BuildDependencies) switchesBuilder.Append(" -d");
 
             return string.Format("{0} {1}{2}", COMMAND_TEXT, ComponentName, switchesBuilder.ToString());
+        }
+
+        public bool Equals(BuildCommand other)
+        {
+            if (other == null) return false;
+
+            return ComponentName == other.ComponentName && BuildDependencies == other.BuildDependencies;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null) return false;
+
+            BuildCommand other = obj as BuildCommand;
+            return Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return ComponentName.GetHashCode() ^ BuildDependencies.GetHashCode();
+        }
+
+        public static bool operator ==(BuildCommand a, BuildCommand b)
+        {
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            if (((object)a == null) || ((object)b == null))
+            {
+                return false;
+            }
+
+            return a.ComponentName == b.ComponentName && a.BuildDependencies == b.BuildDependencies;
+        }
+
+        public static bool operator !=(BuildCommand a, BuildCommand b)
+        {
+            return !(a == b);
         }
     }
 }

--- a/Dewey.Build/BuildCommandHandler.cs
+++ b/Dewey.Build/BuildCommandHandler.cs
@@ -75,7 +75,7 @@ namespace Dewey.Build
 
             if (_command.BuildDependencies)
             {
-                _dependencyElementLoader.LoadFromComponentManifest(_component.ComponentElement);
+                _dependencyElementLoader.LoadFromComponentManifest(_component.ComponentManifest, _component.ComponentElement);
 
                 if (_dependencies.Any())
                 {
@@ -113,7 +113,10 @@ namespace Dewey.Build
 
         public void Handle(DependencyElementResult dependencyElementResult)
         {
-            _dependencies.Add(dependencyElementResult);
+            if (_component.ComponentManifest.Name == dependencyElementResult.ComponentManifest.Name)
+            {
+                _dependencies.Add(dependencyElementResult);
+            }
         }
 
         public void Handle(BuildElementResult buildElementResult)

--- a/Dewey.Build/BuildCommandHandler.cs
+++ b/Dewey.Build/BuildCommandHandler.cs
@@ -21,6 +21,7 @@ namespace Dewey.Build
         readonly IEventAggregator _eventAggregator;
         readonly IBuildActionFactory _buildActionFactory;
         readonly IBuildElementLoader _buildElementLoader;
+        readonly IDependencyElementLoader _dependencyElementLoader;
 
         readonly List<DependencyElementResult> _dependencies;
 
@@ -28,12 +29,13 @@ namespace Dewey.Build
         BuildElementResult _buildElementResult;
         Component _component;
 
-        public BuildCommandHandler(ICommandProcessor commandProcessor, IEventAggregator eventAggregator, IBuildActionFactory buildActionFactory, IBuildElementLoader buildElementLoader)
+        public BuildCommandHandler(ICommandProcessor commandProcessor, IEventAggregator eventAggregator, IBuildActionFactory buildActionFactory, IBuildElementLoader buildElementLoader, IDependencyElementLoader dependencyElementLoader)
         {
             _commandProcessor = commandProcessor;
             _eventAggregator = eventAggregator;
             _buildActionFactory = buildActionFactory;
             _buildElementLoader = buildElementLoader;
+            _dependencyElementLoader = dependencyElementLoader;
 
             _dependencies = new List<DependencyElementResult>();
 
@@ -73,7 +75,7 @@ namespace Dewey.Build
 
             if (_command.BuildDependencies)
             {
-                DependencyElementResult.LoadDependencies(_component.ComponentElement, _eventAggregator);
+                _dependencyElementLoader.LoadFromComponentManifest(_component.ComponentElement);
 
                 if (_dependencies.Any())
                 {

--- a/Dewey.Build/BuildElementLoader.cs
+++ b/Dewey.Build/BuildElementLoader.cs
@@ -1,0 +1,46 @@
+﻿using Dewey.Build.Events;
+using Dewey.Messaging;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Dewey.Build
+{
+    public class BuildElementLoader : IBuildElementLoader
+    {
+        private readonly IEventAggregator _eventAggregator;
+
+        public BuildElementLoader(IEventAggregator eventAggregator)
+        {
+            _eventAggregator = eventAggregator;
+        }
+
+        public void LoadFromComponentManifest(BuildCommand command, XElement componentElement)
+        {
+            var buildsElement = componentElement.Elements().FirstOrDefault(x => x.Name.LocalName == "builds");
+            if (buildsElement == null)
+            {
+                _eventAggregator.PublishEvent(new NoBuildElementsFoundResult(command, componentElement));
+                return;
+            }
+
+            var buildElements = buildsElement.Elements().Where(x => x.Name.LocalName == "build").ToList();
+            if (buildElements.Count == 0)
+            {
+                _eventAggregator.PublishEvent(new NoBuildElementsFoundResult(command, componentElement));
+                return;
+            }
+
+            foreach (var buildElement in buildElements)
+            {
+                var buildTypeAtt = buildElement.Attributes().FirstOrDefault(x => x.Name.LocalName == "type");
+                if (buildTypeAtt == null || string.IsNullOrWhiteSpace(buildTypeAtt.Value))
+                {
+                    _eventAggregator.PublishEvent(new BuildElementMissingTypeAttributeResult(command, buildElement));
+                    continue;
+                }
+
+                _eventAggregator.PublishEvent(new BuildElementResult(command, buildElement, buildTypeAtt.Value));
+            }
+        }
+    }
+}

--- a/Dewey.Build/Dewey.Build.csproj
+++ b/Dewey.Build/Dewey.Build.csproj
@@ -57,6 +57,7 @@
     <Compile Include="BuildCommand.cs" />
     <Compile Include="BuildCommandHandler.cs" />
     <Compile Include="BuildCommandWriter.cs" />
+    <Compile Include="BuildElementLoader.cs" />
     <Compile Include="CLICommandProvider.cs" />
     <Compile Include="Events\BuildActionCompletedResult.cs" />
     <Compile Include="Events\BuildActionEvent.cs" />
@@ -73,6 +74,8 @@
     <Compile Include="Events\MSBuildExecutableNotFoundResult.cs" />
     <Compile Include="Events\NoBuildElementsFoundResult.cs" />
     <Compile Include="IBuildAction.cs" />
+    <Compile Include="IBuildActionFactory.cs" />
+    <Compile Include="IBuildElementLoader.cs" />
     <Compile Include="IMSBuildProcess.cs" />
     <Compile Include="Module.cs" />
     <Compile Include="MSBuild.cs" />

--- a/Dewey.Build/Events/BuildElementResult.cs
+++ b/Dewey.Build/Events/BuildElementResult.cs
@@ -15,33 +15,9 @@ namespace Dewey.Build.Events
             BuildType = buildType;
         }
 
-        public static void LoadBuildElementsFromComponentManifest(BuildCommand command, XElement componentElement, IEventAggregator eventAggregator)
+        public BuildElementResult WithCommand(BuildCommand command)
         {
-            var buildsElement = componentElement.Elements().FirstOrDefault(x => x.Name.LocalName == "builds");
-            if (buildsElement == null)
-            {
-                eventAggregator.PublishEvent(new NoBuildElementsFoundResult(command, componentElement));
-                return;
-            }
-
-            var buildElements = buildsElement.Elements().Where(x => x.Name.LocalName == "build").ToList();
-            if (buildElements.Count == 0)
-            {
-                eventAggregator.PublishEvent(new NoBuildElementsFoundResult(command, componentElement));
-                return;
-            }
-
-            foreach (var buildElement in buildElements)
-            {
-                var buildTypeAtt = buildElement.Attributes().FirstOrDefault(x => x.Name.LocalName == "type");
-                if (buildTypeAtt == null || string.IsNullOrWhiteSpace(buildTypeAtt.Value))
-                {
-                    eventAggregator.PublishEvent(new BuildElementMissingTypeAttributeResult(command, buildElement));
-                    continue;
-                }
-
-                eventAggregator.PublishEvent(new BuildElementResult(command, buildElement, buildTypeAtt.Value));
-            }
+            return new BuildElementResult(command, BuildElement, BuildType);
         }
 
         public override bool Equals(object obj)

--- a/Dewey.Build/IBuildAction.cs
+++ b/Dewey.Build/IBuildAction.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 
 namespace Dewey.Build
 {
-    interface IBuildAction
+    public interface IBuildAction
     {
         string BuildType { get; }
 

--- a/Dewey.Build/IBuildActionFactory.cs
+++ b/Dewey.Build/IBuildActionFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Dewey.Build
+{
+    public interface IBuildActionFactory
+    {
+        IBuildAction CreateBuildAction(string buildType);
+    }
+}

--- a/Dewey.Build/IBuildElementLoader.cs
+++ b/Dewey.Build/IBuildElementLoader.cs
@@ -1,0 +1,9 @@
+﻿using System.Xml.Linq;
+
+namespace Dewey.Build
+{
+    public interface IBuildElementLoader
+    {
+        void LoadFromComponentManifest(BuildCommand command, XElement componentElement);
+    }
+}

--- a/Dewey.Deploy/DeployCommandHandler.cs
+++ b/Dewey.Deploy/DeployCommandHandler.cs
@@ -70,7 +70,7 @@ namespace Dewey.Deploy
 
             if (_command.DeployDependencies)
             {
-                _dependencyElementLoader.LoadFromComponentManifest(_component.ComponentElement);
+                _dependencyElementLoader.LoadFromComponentManifest(_component.ComponentManifest, _component.ComponentElement);
 
                 if (_dependencies.Any())
                 {

--- a/Dewey.Deploy/DeployCommandHandler.cs
+++ b/Dewey.Deploy/DeployCommandHandler.cs
@@ -18,16 +18,19 @@ namespace Dewey.Deploy
     {
         readonly ICommandProcessor _commandProcessor;
         readonly IEventAggregator _eventAggregator;
+        readonly IDependencyElementLoader _dependencyElementLoader;
+
         readonly List<DependencyElementResult> _dependencies;
 
         DeployCommand _command;
         Component _component;
         DeploymentElementResult _deploymentElementResult;
 
-        public DeployCommandHandler(ICommandProcessor commandProcessor, IEventAggregator eventAggregator)
+        public DeployCommandHandler(ICommandProcessor commandProcessor, IEventAggregator eventAggregator, IDependencyElementLoader dependencyElementLoader)
         {
             _commandProcessor = commandProcessor;
             _eventAggregator = eventAggregator;
+            _dependencyElementLoader = dependencyElementLoader;
 
             _dependencies = new List<DependencyElementResult>();
 
@@ -67,7 +70,7 @@ namespace Dewey.Deploy
 
             if (_command.DeployDependencies)
             {
-                DependencyElementResult.LoadDependencies(_component.ComponentElement, _eventAggregator);
+                _dependencyElementLoader.LoadFromComponentManifest(_component.ComponentElement);
 
                 if (_dependencies.Any())
                 {

--- a/Dewey.Manifest/Component/ComponentManifest.cs
+++ b/Dewey.Manifest/Component/ComponentManifest.cs
@@ -23,6 +23,11 @@ namespace Dewey.Manifest.Component
             File = file;
         }
 
+        public ComponentManifest WithName(string name)
+        {
+            return new ComponentManifest(name, Type, File);
+        }
+
         public static ComponentManifestLoadResult LoadComponentItem(ComponentItem componentItem, IManifestFileReaderService manifestFileReaderService)
         {
             var componentManifestFile = manifestFileReaderService.ReadComponentManifestFile(componentItem.RepositoryManifest.DirectoryName, componentItem.RelativeLocation);

--- a/Dewey.Manifest/Dependency/DependencyElementLoader.cs
+++ b/Dewey.Manifest/Dependency/DependencyElementLoader.cs
@@ -1,0 +1,58 @@
+﻿using Dewey.Messaging;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Dewey.Manifest.Dependency
+{
+    public class DependencyElementLoader : IDependencyElementLoader
+    {
+        private readonly IEventAggregator _eventAggregator;
+
+        public DependencyElementLoader(IEventAggregator eventAggregator)
+        {
+            _eventAggregator = eventAggregator;
+        }
+
+        public void LoadFromComponentManifest(XElement componentElement)
+        {
+            var dependenciesElement = componentElement.Elements().FirstOrDefault(x => x.Name.LocalName == "dependencies");
+            if (dependenciesElement == null)
+            {
+                _eventAggregator.PublishEvent(new DependenciesElementNotFoundResult(componentElement));
+                return;
+            }
+
+            var dependencyElements = dependenciesElement.Elements().Where(x => x.Name.LocalName == "dependency").ToList();
+            if (dependencyElements.Count == 0)
+            {
+                _eventAggregator.PublishEvent(new DependencyElementsNotFoundResult(componentElement));
+                return;
+            }
+
+            foreach (var dependencyElement in dependencyElements)
+            {
+                var missingAttributes = new List<string>();
+                var dependencyTypeAtt = dependencyElement.Attributes().FirstOrDefault(x => x.Name.LocalName == "type");
+                if (dependencyTypeAtt == null || string.IsNullOrWhiteSpace(dependencyTypeAtt.Value))
+                {
+                    missingAttributes.Add("type");
+                }
+
+                var dependencyNameAtt = dependencyElement.Attributes().FirstOrDefault(x => x.Name.LocalName == "name");
+                if (dependencyNameAtt == null || string.IsNullOrWhiteSpace(dependencyNameAtt.Value))
+                {
+                    missingAttributes.Add("name");
+                }
+
+                if (missingAttributes.Any())
+                {
+                    _eventAggregator.PublishEvent(new DependencyElementMissingAttributesResult(componentElement, missingAttributes));
+                    continue;
+                }
+
+                _eventAggregator.PublishEvent(new DependencyElementResult(dependencyElement, dependencyTypeAtt.Value, dependencyNameAtt.Value));
+            }
+        }
+    }
+}

--- a/Dewey.Manifest/Dependency/DependencyElementLoader.cs
+++ b/Dewey.Manifest/Dependency/DependencyElementLoader.cs
@@ -1,4 +1,5 @@
-﻿using Dewey.Messaging;
+﻿using Dewey.Manifest.Component;
+using Dewey.Messaging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
@@ -14,7 +15,7 @@ namespace Dewey.Manifest.Dependency
             _eventAggregator = eventAggregator;
         }
 
-        public void LoadFromComponentManifest(XElement componentElement)
+        public void LoadFromComponentManifest(ComponentManifest componentMandifest, XElement componentElement)
         {
             var dependenciesElement = componentElement.Elements().FirstOrDefault(x => x.Name.LocalName == "dependencies");
             if (dependenciesElement == null)
@@ -51,7 +52,7 @@ namespace Dewey.Manifest.Dependency
                     continue;
                 }
 
-                _eventAggregator.PublishEvent(new DependencyElementResult(dependencyElement, dependencyTypeAtt.Value, dependencyNameAtt.Value));
+                _eventAggregator.PublishEvent(new DependencyElementResult(componentMandifest, dependencyElement, dependencyTypeAtt.Value, dependencyNameAtt.Value));
             }
         }
     }

--- a/Dewey.Manifest/Dependency/DependencyElementResult.cs
+++ b/Dewey.Manifest/Dependency/DependencyElementResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Linq;
+﻿using Dewey.Manifest.Component;
+using System.Xml.Linq;
 
 namespace Dewey.Manifest.Dependency
 {
@@ -6,12 +7,14 @@ namespace Dewey.Manifest.Dependency
     {
         public const string COMPONENT_DEPENDENCY_TYPE = "component";
 
+        public ComponentManifest ComponentManifest { get; private set; }
         public XElement DependencyElement { get; private set; }
         public string Type { get; private set; }
         public string Name { get; private set; }
 
-        public DependencyElementResult(XElement dependencyElement, string type, string name)
+        public DependencyElementResult(ComponentManifest componentMandifest, XElement dependencyElement, string type, string name)
         {
+            ComponentManifest = componentMandifest;
             DependencyElement = dependencyElement;
             Type = type;
             Name = name;
@@ -19,7 +22,12 @@ namespace Dewey.Manifest.Dependency
 
         public DependencyElementResult WithType(string type)
         {
-            return new DependencyElementResult(DependencyElement, type, Name);
+            return new DependencyElementResult(ComponentManifest, DependencyElement, type, Name);
+        }
+
+        public DependencyElementResult WithComponentManifest(ComponentManifest componentMandifest)
+        {
+            return new DependencyElementResult(componentMandifest, DependencyElement, Type, Name);
         }
     }
 }

--- a/Dewey.Manifest/Dependency/DependencyElementResult.cs
+++ b/Dewey.Manifest/Dependency/DependencyElementResult.cs
@@ -1,7 +1,4 @@
-﻿using Dewey.Messaging;
-using System.Collections.Generic;
-using System.Linq;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 
 namespace Dewey.Manifest.Dependency
 {
@@ -20,45 +17,9 @@ namespace Dewey.Manifest.Dependency
             Name = name;
         }
 
-        public static void LoadDependencies(XElement componentElement, IEventAggregator eventAggregator)
+        public DependencyElementResult WithType(string type)
         {
-            var dependenciesElement = componentElement.Elements().FirstOrDefault(x => x.Name.LocalName == "dependencies");
-            if (dependenciesElement == null)
-            {
-                eventAggregator.PublishEvent(new DependenciesElementNotFoundResult(componentElement));
-                return;
-            }
-
-            var dependencyElements = dependenciesElement.Elements().Where(x => x.Name.LocalName == "dependency").ToList();
-            if (dependencyElements.Count == 0)
-            {
-                eventAggregator.PublishEvent(new DependencyElementsNotFoundResult(componentElement));
-                return;
-            }
-
-            foreach (var dependencyElement in dependencyElements)
-            {
-                var missingAttributes = new List<string>();
-                var dependencyTypeAtt = dependencyElement.Attributes().FirstOrDefault(x => x.Name.LocalName == "type");
-                if (dependencyTypeAtt == null || string.IsNullOrWhiteSpace(dependencyTypeAtt.Value))
-                {
-                    missingAttributes.Add("type");
-                }
-
-                var dependencyNameAtt = dependencyElement.Attributes().FirstOrDefault(x => x.Name.LocalName == "name");
-                if (dependencyNameAtt == null || string.IsNullOrWhiteSpace(dependencyNameAtt.Value))
-                {
-                    missingAttributes.Add("name");
-                }
-
-                if (missingAttributes.Any())
-                {
-                    eventAggregator.PublishEvent(new DependencyElementMissingAttributesResult(componentElement, missingAttributes));
-                    continue;
-                }
-
-                eventAggregator.PublishEvent(new DependencyElementResult(dependencyElement, dependencyTypeAtt.Value, dependencyNameAtt.Value));
-            }
+            return new DependencyElementResult(DependencyElement, type, Name);
         }
     }
 }

--- a/Dewey.Manifest/Dependency/IDependencyElementLoader.cs
+++ b/Dewey.Manifest/Dependency/IDependencyElementLoader.cs
@@ -1,0 +1,9 @@
+﻿using System.Xml.Linq;
+
+namespace Dewey.Manifest.Dependency
+{
+    public interface IDependencyElementLoader
+    {
+        void LoadFromComponentManifest(XElement componentElement);
+    }
+}

--- a/Dewey.Manifest/Dependency/IDependencyElementLoader.cs
+++ b/Dewey.Manifest/Dependency/IDependencyElementLoader.cs
@@ -1,9 +1,10 @@
-﻿using System.Xml.Linq;
+﻿using Dewey.Manifest.Component;
+using System.Xml.Linq;
 
 namespace Dewey.Manifest.Dependency
 {
     public interface IDependencyElementLoader
     {
-        void LoadFromComponentManifest(XElement componentElement);
+        void LoadFromComponentManifest(ComponentManifest componentMandifest, XElement componentElement);
     }
 }

--- a/Dewey.Manifest/Dewey.Manifest.csproj
+++ b/Dewey.Manifest/Dewey.Manifest.csproj
@@ -48,9 +48,11 @@
     <Compile Include="Component\ComponentManifestLoadResult.cs" />
     <Compile Include="Dependency\DependenciesElementNotFoundResult.cs" />
     <Compile Include="Dependency\DependencyElementEvent.cs" />
+    <Compile Include="Dependency\DependencyElementLoader.cs" />
     <Compile Include="Dependency\DependencyElementMissingAttributesResult.cs" />
     <Compile Include="Dependency\DependencyElementResult.cs" />
     <Compile Include="Dependency\DependencyElementsNotFoundResult.cs" />
+    <Compile Include="Dependency\IDependencyElementLoader.cs" />
     <Compile Include="Events\LoadManifestFilesResult.cs" />
     <Compile Include="Events\ManifestFilesFound.cs" />
     <Compile Include="Events\NoManifestFileFoundResult.cs" />

--- a/Dewey.State/Component.cs
+++ b/Dewey.State/Component.cs
@@ -14,5 +14,10 @@ namespace Dewey.State
             ComponentManifest = componentManifest;
             ComponentElement = componentElement;
         }
+
+        public Component WithComponentMandifest(ComponentManifest componentManifest)
+        {
+            return new Component(componentManifest, ComponentElement);
+        }
     }
 }

--- a/Dewey.State/Messages/GetComponent.cs
+++ b/Dewey.State/Messages/GetComponent.cs
@@ -7,13 +7,53 @@ using System.Threading.Tasks;
 
 namespace Dewey.State.Messages
 {
-    public class GetComponent : ICommand
+    public class GetComponent : ICommand, IEquatable<GetComponent>
     {
-        public string ComponentName { get; private set; }
+        public string ComponentName { get; protected set; }
 
         public GetComponent(string componentName)
         {
             ComponentName = componentName;
+        }
+
+        public bool Equals(GetComponent other)
+        {
+            if (other == null) return false;
+
+            return ComponentName == other.ComponentName;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null) return false;
+
+            GetComponent other = obj as GetComponent;
+            return Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return ComponentName.GetHashCode();
+        }
+
+        public static bool operator ==(GetComponent a, GetComponent b)
+        {
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            if (((object)a == null) || ((object)b == null))
+            {
+                return false;
+            }
+
+            return a.ComponentName == b.ComponentName;
+        }
+
+        public static bool operator !=(GetComponent a, GetComponent b)
+        {
+            return !(a == b);
         }
     }
 
@@ -26,6 +66,16 @@ namespace Dewey.State.Messages
         {
             Command = command;
             Component = component;
+        }
+
+        public GetComponentResult WithCommand(GetComponent command)
+        {
+            return new GetComponentResult(command, Component);
+        }
+
+        public GetComponentResult WithComponent(Component component)
+        {
+            return new GetComponentResult(Command, component);
         }
     }
 }


### PR DESCRIPTION
This fixes #5 by making BuildCommandHandler only use dependencies loaded from the component manifest being built.
